### PR TITLE
Fix location of config files in binary distribution, and add defaults for Elasticsearch

### DIFF
--- a/netdata/config.sls
+++ b/netdata/config.sls
@@ -16,3 +16,15 @@ netdata-config:
       - service: netdata_service_running
     - require:
       - cmd: install_netdata
+
+{% for config_file, settings in netdata.plugin_configs.items() %}
+netdata-plugin-{{ config_file }}:
+  file.managed:
+    - name: {{ config_file }}
+    - contents: {{ settings | yaml() }}
+    - makedirs: True
+    - watch_in:
+      - service: netdata_service_running
+    - require:
+      - cmd: install_netdata
+{% endfor %}

--- a/netdata/map.jinja
+++ b/netdata/map.jinja
@@ -1,3 +1,12 @@
+{# Netdata configuration defaults.
+
+   Includes defaults for the Elasticsearch plugin to keep it from incurring
+   too much CPU usage with its cluster and indices API stats requests.
+   Elasticsearch nodes may also benefit from a longer "update every" setting
+   than the default of 1. You can specify this in the pillar for the node,
+   under `netdata:config:global'.
+#}
+
 {% set netdata = salt.grains.filter_by({
     'default': {
         'pkgs': ['netdata'],
@@ -7,6 +16,18 @@
             'global': {
                 'hostname': salt.grains.get('id'),
                 'memory mode': 'dbengine'
+            }
+        },
+        'plugin_configs': {
+            '/opt/netdata/etc/netdata/python.d/elasticsearch.conf': {
+                'local': {
+                    'host': '127.0.0.1',
+                    'port': '9200',
+                    'node_status': 'yes',
+                    'cluster_health': 'yes',
+                    'cluster_stats': 'no',
+                    'indices_stats': 'no'
+                }
             }
         },
     },

--- a/netdata/map.jinja
+++ b/netdata/map.jinja
@@ -2,7 +2,7 @@
     'default': {
         'pkgs': ['netdata'],
         'service': 'netdata',
-        'conf_file': '/etc/netdata/netdata.conf',
+        'conf_file': '/opt/netdata/etc/netdata/netdata.conf',
         'config': {
             'global': {
                 'hostname': salt.grains.get('id'),


### PR DESCRIPTION
This formula installs the binary distribution of Netdata, which puts its configuration files under a different folder tree than what's given in most of their documentation examples. This PR changes the location of the main `netdata.conf` file.

In addition, we have found that the default settings for the Elasticsearch plugin incur unwanted CPU usage, so I'm introducing better defaults for that plugin.
